### PR TITLE
add video display

### DIFF
--- a/text_to_video_synthesis.ipynb
+++ b/text_to_video_synthesis.ipynb
@@ -44,7 +44,9 @@
         "from modelscope.outputs import OutputKeys\n",
         "\n",
         "torch.manual_seed(random.randint(0, 2147483647))\n",
-        "pipe = pipeline('text-to-video-synthesis', '/content/models')"
+        "pipe = pipeline('text-to-video-synthesis', '/content/models')\n",
+        "\n",
+        "!mkdir /content/videos"
       ]
     },
     {
@@ -54,6 +56,9 @@
       "outputs": [],
       "source": [
         "import gc\n",
+        "import datetime\n",
+        "from IPython.display import HTML\n",
+        "\n",
         "with torch.no_grad():\n",
         "  torch.cuda.empty_cache()\n",
         "gc.collect()\n",
@@ -62,10 +67,25 @@
         "        'text': 'A panda eating bamboo on a rock.',\n",
         "    }\n",
         "output_video_path = pipe(test_text,)[OutputKeys.OUTPUT_VIDEO]\n",
-        "print(output_video_path)\n",
         "\n",
-        "!mkdir /content/videos\n",
-        "!cp /tmp/*.mp4 /content/videos"
+        "new_video_path = f'/content/videos/{datetime.datetime.now().strftime(\"%Y-%m-%d_%H:%M:%S\")}.mp4'\n",
+        "!mv {output_video_path} {new_video_path}\n",
+        "print(output_video_path, '->', new_video_path)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from IPython.display import HTML\n",
+        "from base64 import b64encode\n",
+        "!ffmpeg -y -i {new_video_path} -c:v libx264 -c:a aac -strict -2 /content/videos/tmp.mp4 >/dev/null 2>&1\n",
+        "mp4 = open('/content/videos/tmp.mp4','rb').read()\n",
+        "\n",
+        "decoded_vid = \"data:video/mp4;base64,\" + b64encode(mp4).decode()\n",
+        "HTML(f'<video width=400 controls><source src=\"{decoded_vid}\" type=\"video/mp4\"></video>')"
       ]
     }
   ],


### PR DESCRIPTION
There are several changes in this request:
1. I moved 'videos' creation into a second cell as it need to be called only ones
2. I replaced 'cp' command with 'mv' so we do not use extra space by coping files.
3. Name of the new video file generated from timestamp so it's easy to see where is the new file along others.
4. I added a cell that display video. For some reason it does not work with the videos generated by the model so I do some conversion with ffmpeg to make video readable before showing it.